### PR TITLE
allow stderr output to percolate up to docker logs

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -2,7 +2,4 @@
 set -e
 
 # Start Radsecproxy
-/sbin/radsecproxy -c /etc/radsecproxy.conf -i /var/run/radsecproxy.pid
-
-# Keep container running
-/usr/bin/tail -f /dev/null
+/sbin/radsecproxy -f -c /etc/radsecproxy.conf -i /var/run/radsecproxy.pid


### PR DESCRIPTION
With `LogDestination` not set, `radsecproxy` will emit logs to `stderr` where the managing Docker process can collect the logs.